### PR TITLE
Apply CRDs before anything else

### DIFF
--- a/cmd/kustomizer/apply.go
+++ b/cmd/kustomizer/apply.go
@@ -28,6 +28,7 @@ var (
 	timeout            time.Duration
 	cfgNamespace       string
 	buildWithKustomize bool
+	dryRun             bool
 )
 
 func init() {
@@ -37,6 +38,7 @@ func init() {
 	applyCmd.Flags().StringVarP(&cfgNamespace, "gc-namespace", "", "default", "namespace to store the GC snapshot ConfigMap")
 	applyCmd.Flags().DurationVar(&timeout, "timeout", 5*time.Minute, "timeout for this operation")
 	applyCmd.Flags().BoolVar(&buildWithKustomize, "use-kustomize", false, "use Kustomize binary for build operations")
+	applyCmd.Flags().BoolVar(&dryRun, "dry-run", false, "dry-run apply")
 
 	rootCmd.AddCommand(applyCmd)
 }
@@ -113,7 +115,7 @@ func applyCmdRun(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	err = applier.Run(manifest, false)
+	err = applier.Run(manifest, dryRun)
 	if err != nil {
 		return err
 	}

--- a/pkg/engine/applier.go
+++ b/pkg/engine/applier.go
@@ -5,11 +5,17 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"time"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/yaml"
 	"sigs.k8s.io/kustomize/api/filesys"
+	yaml2 "sigs.k8s.io/yaml"
 )
 
 type Applier struct {
@@ -28,19 +34,96 @@ func NewApplier(fs filesys.FileSystem, timeout time.Duration) (*Applier, error) 
 	}, nil
 }
 
-func (a *Applier) Run(filePath string, dryRun bool) error {
-	if !a.fs.Exists(filePath) {
-		return fmt.Errorf("%s not found", filePath)
+func (a *Applier) Run(manifestPath string, dryRun bool) error {
+	if !a.fs.Exists(manifestPath) {
+		return fmt.Errorf("%s not found", manifestPath)
+	}
+
+	crds, err := a.ExtractCRDs(manifestPath)
+	if err != nil {
+		return err
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), a.timeout+time.Second)
 	defer cancel()
 
-	command := fmt.Sprintf("kubectl apply -f %s --timeout=%s", filePath, a.timeout.String())
+	if crds != "" {
+		command := fmt.Sprintf("kubectl apply -f %s --timeout=%s", crds, a.timeout.String())
+		if dryRun {
+			command = fmt.Sprintf("%s --dry-run=client", command)
+		}
+
+		if err := a.exec(ctx, command); err != nil {
+			return err
+		}
+	}
+
+	command := fmt.Sprintf("kubectl apply -f %s --timeout=%s", manifestPath, a.timeout.String())
 	if dryRun {
 		command = fmt.Sprintf("%s --dry-run=client", command)
 	}
 
+	if err := a.exec(ctx, command); err != nil {
+		return err
+	} else {
+		return nil
+	}
+}
+
+func (a *Applier) ExtractCRDs(manifestPath string) (string, error) {
+	manifests, err := ioutil.ReadFile(manifestPath)
+	if err != nil {
+		return "", err
+	}
+
+	crds := ""
+	reader := yaml.NewYAMLOrJSONDecoder(bytes.NewReader(manifests), 2048)
+	for {
+		var obj unstructured.Unstructured
+		err := reader.Decode(&obj)
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return "", err
+		}
+		if obj.IsList() {
+			err := obj.EachListItem(func(item runtime.Object) error {
+				return nil
+			})
+			if err != nil {
+				return "", err
+			}
+		} else {
+			if obj.GetKind() == "CustomResourceDefinition" {
+				b, err := obj.MarshalJSON()
+				if err != nil {
+					return "", err
+				}
+
+				y, err := yaml2.JSONToYAML(b)
+				if err != nil {
+					return "", err
+				}
+				crds += "---\n" + string(y)
+			}
+		}
+	}
+
+	if crds == "" {
+		return "", nil
+	}
+
+	base := filepath.Dir(manifestPath)
+	crdsFile := filepath.Join(base, "extracted-crds.yaml")
+
+	if err := ioutil.WriteFile(crdsFile, []byte(crds), os.ModePerm); err != nil {
+		return "", err
+	}
+
+	return crdsFile, nil
+}
+
+func (a *Applier) exec(ctx context.Context, command string) error {
 	var stdoutBuf, stderrBuf bytes.Buffer
 	c := exec.CommandContext(ctx, "/bin/sh", "-c", command)
 	c.Stdout = io.MultiWriter(os.Stdout, &stdoutBuf)

--- a/testdata/crds/definitions/crd.yaml
+++ b/testdata/crds/definitions/crd.yaml
@@ -1,0 +1,33 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: tests.testing.k8s.io
+spec:
+  group: testing.k8s.io
+  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
+  names:
+    plural: tests
+    singular: test
+    kind: Test
+  scope: Namespaced
+  subresources:
+    status: {}
+  additionalPrinterColumns:
+    - name: Type
+      type: string
+      JSONPath: .spec.type
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            type:
+              description: Type of test
+              type: string
+              enum:
+                - unit
+                - integration

--- a/testdata/crds/resources/cr.yaml
+++ b/testdata/crds/resources/cr.yaml
@@ -1,0 +1,7 @@
+apiVersion: testing.k8s.io/v1
+kind: Test
+metadata:
+  name: some-test
+  namespace: default
+spec:
+  type: integration


### PR DESCRIPTION
This PR allows applying CRDs and CRs by extracting the CRDs from the manifests and applying them before anything else. 