### PR TITLE
Add capability to apply adhoc patches

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -59,6 +59,10 @@ jobs:
           rm -rf testdata/plain/frontend
           ./bin/kustomizer apply -i kustomizer-demo -f testdata/plain/ --wait --prune
           kubectl -n kustomizer-demo get svc frontend 2>&1 | grep NotFound
+      - name: Test apply --patch
+        run: |
+          ./bin/kustomizer apply -i kustomizer-demo -f testdata/plain/ -p testdata/patches/safe-to-evict.yaml --wait --prune
+          kubectl -n kustomizer-demo get deployment backend -oyaml | grep safe-to-evict
       - name: Test delete --wait
         run: |
           ./bin/kustomizer delete -i kustomizer-demo --wait

--- a/cmd/kustomizer/apply.go
+++ b/cmd/kustomizer/apply.go
@@ -32,13 +32,14 @@ import (
 
 var applyCmd = &cobra.Command{
 	Use:   "apply",
-	Short: "Apply Kubernetes manifests and Kustomize overlays using server-side apply.",
+	Short: "Apply validates the given Kubernetes manifests and Kustomize overlays and reconciles them using server-side apply.",
 	RunE:  runApplyCmd,
 }
 
 type applyFlags struct {
 	filename           []string
 	kustomize          string
+	patch              []string
 	inventoryName      string
 	inventoryNamespace string
 	wait               bool
@@ -55,6 +56,8 @@ func init() {
 		"Path to Kubernetes manifest(s). If a directory is specified, then all manifests in the directory tree will be processed recursively.")
 	applyCmd.Flags().StringVarP(&applyArgs.kustomize, "kustomize", "k", "",
 		"Path to a directory that contains a kustomization.yaml.")
+	applyCmd.Flags().StringSliceVarP(&applyArgs.patch, "patch", "p", nil,
+		"Path to a kustomization file that contains a list of patches.")
 	applyCmd.Flags().BoolVar(&applyArgs.wait, "wait", false, "Wait for the applied Kubernetes objects to become ready.")
 	applyCmd.Flags().BoolVar(&applyArgs.force, "force", false, "Recreate objects that contain immutable fields changes.")
 	applyCmd.Flags().BoolVar(&applyArgs.prune, "prune", false, "Delete stale objects from the cluster.")
@@ -79,7 +82,7 @@ func runApplyCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	logger.Println("building inventory...")
-	objects, err := buildManifests(applyArgs.kustomize, applyArgs.filename)
+	objects, err := buildManifests(applyArgs.kustomize, applyArgs.filename, applyArgs.patch)
 	if err != nil {
 		return err
 	}

--- a/cmd/kustomizer/diff.go
+++ b/cmd/kustomizer/diff.go
@@ -37,6 +37,7 @@ var diffCmd = &cobra.Command{
 type diffFlags struct {
 	filename           []string
 	kustomize          string
+	patch              []string
 	inventoryName      string
 	inventoryNamespace string
 	prune              bool
@@ -49,6 +50,8 @@ func init() {
 		"Path to Kubernetes manifest(s). If a directory is specified, then all manifests in the directory tree will be processed recursively.")
 	diffCmd.Flags().StringVarP(&diffArgs.kustomize, "kustomize", "k", "",
 		"Path to a directory that contains a kustomization.yaml.")
+	diffCmd.Flags().StringSliceVarP(&diffArgs.patch, "patch", "p", nil,
+		"Path to a kustomization file that contains a list of patches.")
 	diffCmd.Flags().BoolVar(&diffArgs.prune, "prune", false, "Delete stale objects from the cluster.")
 	diffCmd.Flags().StringVarP(&diffArgs.inventoryName, "inventory-name", "i", "", "The name of the inventory configmap.")
 	diffCmd.Flags().StringVar(&diffArgs.inventoryNamespace, "inventory-namespace", "default",
@@ -61,7 +64,7 @@ func runDiffCmd(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("-f or -k is required")
 	}
 
-	objects, err := buildManifests(diffArgs.kustomize, diffArgs.filename)
+	objects, err := buildManifests(diffArgs.kustomize, diffArgs.filename, diffArgs.patch)
 	if err != nil {
 		return err
 	}

--- a/cmd/kustomizer/get.go
+++ b/cmd/kustomizer/get.go
@@ -22,7 +22,7 @@ import (
 
 var getCmd = &cobra.Command{
 	Use:   "get",
-	Short: "Get prints the content of inventories.",
+	Short: "Get prints the content of inventories and their source revision.",
 }
 
 type getFlags struct {

--- a/testdata/patches/safe-to-evict.yaml
+++ b/testdata/patches/safe-to-evict.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+  - target:
+      kind: Deployment
+    patch: |
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: all
+      spec:
+        template:
+          metadata:
+            annotations:
+              cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/testdata/patches/security-context.yaml
+++ b/testdata/patches/security-context.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+  - target:
+      kind: Deployment
+    patch: |
+      - op: add
+        path: /spec/template/spec/securityContext
+        value:
+          runAsUser: 10000
+          fsGroup: 1337
+      - op: add
+        path: /spec/template/spec/containers/0/securityContext
+        value:
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          capabilities:
+            drop:
+              - ALL


### PR DESCRIPTION
This PR adds an optional argument called `--patch` with which you can supply addition kustomize patches.

## Example

When the manifests source is read-only, you may want to apply ad hoc patches such as making all deployments conform to Kubernetes restricted pod security policy.

First create a file called `patch-security-context.yaml` with the following content:

```yaml
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization
patches:
  - target:
      kind: Deployment
    patch: |
      - op: add
        path: /spec/template/spec/securityContext
        value:
          runAsUser: 10000
          fsGroup: 1337
      - op: add
        path: /spec/template/spec/containers/0/securityContext
        value:
          readOnlyRootFilesystem: true
          allowPrivilegeEscalation: false
          runAsNonRoot: true
          capabilities:
            drop:
              - ALL
```

Now you can apply the manifests from `testdata/plain` patched with the above definition:

```sh
kustomizer apply  -i demo  --prune  --wait \
   -f ./testdata/plain/ \
   --patch patch-security-context.yaml
```
