### PR TITLE
Sign release artifacts with cosign

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,9 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: 1.17.x
+      - uses: sigstore/cosign-installer@main
+      - name: Write signing key to tmp
+        run: echo "${{ secrets.COSIGN_KEY }}" > /tmp/cosign.key
       - name: Download release notes utility
         env:
           GH_REL_URL: https://github.com/buchanae/github-release-notes/releases/download/0.2.0/github-release-notes-linux-amd64-0.2.0.tar.gz
@@ -31,3 +34,4 @@ jobs:
           args: release --release-notes=/tmp/release.txt --skip-validate
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -39,3 +39,8 @@ archives:
     format: zip
     files:
       - LICENSE
+signs:
+  - cmd: cosign
+    stdin: '{{ .Env.COSIGN_PASSWORD }}'
+    args: ["sign-blob", "--key=/tmp/cosign.key", "--output=${signature}", "${artifact}"]
+    artifacts: all


### PR DESCRIPTION
Starting with next version, kustomizer release assets are signed with cosign.