### PR TITLE
Verify release during install with cosign

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,11 @@ the binaries can be downloaded form GitHub [release page](https://github.com/ste
 Install the latest release on macOS or Linux with [this script](install/README.md):
 
 ```bash
-curl -s https://kustomizer.dev/install.sh | bash
+curl -s https://kustomizer.dev/install.sh | sudo bash
 ```
+
+If [cosign](https://github.com/sigstore/cosign) is found in PATH, the script will verify the signature
+of the release using the public key from [kustomizer.dev/verify/cosign.pub](https://kustomizer.dev/verify/cosign.pub).
 
 Or from source with Go:
 

--- a/install/README.md
+++ b/install/README.md
@@ -8,10 +8,20 @@ curl -s https://raw.githubusercontent.com/stefanprodan/kustomizer/main/install/k
 
 The install script does the following:
 * attempts to detect your OS
-* downloads and unpacks the [release tar file](https://github.com/stefanprodan/kustomizer/releases) in a temporary directory
+* downloads the [release tar file](https://github.com/stefanprodan/kustomizer/releases) and its signature in a temporary directory
+* verifies the [cosign](https://github.com/sigstore/cosign) signature with [kustomizer.dev/verify/cosign.pub](https://kustomizer.dev/verify/cosign.pub)
+* unpacks the release tar file
 * verifies the binary checksum
 * copies the kustomizer binary to `/usr/local/bin`
 * removes the temporary directory
+
+## Install from source
+
+Using Go >= 1.17:
+
+```sh
+go install github.com/stefanprodan/kustomizer/cmd/kustomizer@latest
+```
 
 ## Build from source
 
@@ -22,7 +32,7 @@ git clone https://github.com/stefanprodan/kustomizer
 cd kustomizer
 ```
 
-Build the kustomizer binary (requires go >= 1.16):
+Build the kustomizer binary (requires go >= 1.17):
 
 ```bash
 make build


### PR DESCRIPTION
If [cosign](https://github.com/sigstore/cosign) is found in PATH, the install script will verify the signature
of the release using the public key from [kustomizer.dev/verify/cosign.pub](https://kustomizer.dev/verify/cosign.pub).