### PR TITLE
Introduce Kustomizer configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,13 @@ The Kustomize CLI offers the following commands:
 * `get`    Prints the content of inventories and their source revision.
 * `diff`   Diff compares the local Kubernetes manifests with the in-cluster objects and prints the YAML diff to stdout.
 * `delete` Delete removes the Kubernetes objects in the inventory from the cluster and waits for termination.
+* `config` Manage kustomizer config files.
 * `completion` Generates completion scripts for bash, fish, powershell and zsh.
+* `help`       Help about any command.
+
+To connect to Kubernetes API, Kustomizer uses the current context from `~/.kube/config`.
+You can set a different context with `--context`.
+You can also specify a different kubeconfig with `--kubeconfig` or with the `KUBECONFIG` env var.
 
 ## Get Started
 

--- a/cmd/kustomizer/build.go
+++ b/cmd/kustomizer/build.go
@@ -74,19 +74,21 @@ func runBuildCmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	sort.Sort(ssa.SortableUnstructureds(objects))
+
 	switch buildArgs.output {
 	case "yaml":
 		yml, err := ssa.ObjectsToYAML(objects)
 		if err != nil {
 			return err
 		}
-		fmt.Println(yml)
+		rootCmd.Println(yml)
 	case "json":
 		json, err := ssa.ObjectsToJSON(objects)
 		if err != nil {
 			return err
 		}
-		fmt.Println(json)
+		rootCmd.Println(json)
 	default:
 		return fmt.Errorf("unsupported output, can be yaml or json")
 	}
@@ -149,7 +151,6 @@ func buildManifests(kustomizePath string, filePaths []string, patchPaths []strin
 		}
 	}
 
-	sort.Sort(ssa.SortableUnstructureds(objects))
 	return objects, nil
 }
 

--- a/cmd/kustomizer/config.go
+++ b/cmd/kustomizer/config.go
@@ -20,11 +20,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var getCmd = &cobra.Command{
-	Use:   "get",
-	Short: "Get prints the content of inventories and their source revision.",
+var configCmd = &cobra.Command{
+	Use:   "config",
+	Short: "Manage kustomizer config files.",
 }
 
 func init() {
-	rootCmd.AddCommand(getCmd)
+	rootCmd.AddCommand(configCmd)
 }

--- a/cmd/kustomizer/config_init.go
+++ b/cmd/kustomizer/config_init.go
@@ -18,13 +18,30 @@ package main
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/stefanprodan/kustomizer/pkg/config"
 )
 
-var getCmd = &cobra.Command{
-	Use:   "get",
-	Short: "Get prints the content of inventories and their source revision.",
+var configInit = &cobra.Command{
+	Use:   "init",
+	Short: "Init writes a config file with default values at '$HOME/.kustomizer/config'.",
+	RunE:  runConfigInitCmd,
 }
 
 func init() {
-	rootCmd.AddCommand(getCmd)
+	configCmd.AddCommand(configInit)
+}
+
+func runConfigInitCmd(cmd *cobra.Command, args []string) error {
+	cfgPath, err := config.DefaultConfigPath()
+	if err != nil {
+		return err
+	}
+
+	c := config.NewConfig()
+	if err := c.Write(""); err != nil {
+		return err
+	}
+
+	logger.Println("config written to", cfgPath)
+	return nil
 }

--- a/cmd/kustomizer/config_view.go
+++ b/cmd/kustomizer/config_view.go
@@ -18,13 +18,25 @@ package main
 
 import (
 	"github.com/spf13/cobra"
+	"sigs.k8s.io/yaml"
 )
 
-var getCmd = &cobra.Command{
-	Use:   "get",
-	Short: "Get prints the content of inventories and their source revision.",
+var configView = &cobra.Command{
+	Use: "view",
+	Short: "Display the config values from '$HOME/.kustomizer/config'. " +
+		"If no config file is found, the default in-memory values are displayed.",
+	RunE: runConfigViewCmd,
 }
 
 func init() {
-	rootCmd.AddCommand(getCmd)
+	configCmd.AddCommand(configView)
+}
+
+func runConfigViewCmd(cmd *cobra.Command, args []string) error {
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		return err
+	}
+	rootCmd.Println(string(data))
+	return nil
 }

--- a/cmd/kustomizer/config_view_test.go
+++ b/cmd/kustomizer/config_view_test.go
@@ -17,14 +17,18 @@ limitations under the License.
 package main
 
 import (
-	"github.com/spf13/cobra"
+	"testing"
+
+	. "github.com/onsi/gomega"
 )
 
-var getCmd = &cobra.Command{
-	Use:   "get",
-	Short: "Get prints the content of inventories and their source revision.",
-}
+func TestConfigView(t *testing.T) {
+	g := NewWithT(t)
+	kind := "NetworkPolicy"
+	cfg.ApplyOrder.First = append(cfg.ApplyOrder.First, kind)
+	output, err := executeCommand("config view")
 
-func init() {
-	rootCmd.AddCommand(getCmd)
+	g.Expect(err).NotTo(HaveOccurred())
+	t.Logf("\n%s", output)
+	g.Expect(output).To(MatchRegexp(kind))
 }

--- a/cmd/kustomizer/get_inventories.go
+++ b/cmd/kustomizer/get_inventories.go
@@ -40,7 +40,7 @@ func init() {
 
 func runGetInventoriesCmd(cmd *cobra.Command, args []string) error {
 
-	if getArgs.namespace == "" {
+	if kubeconfigArgs.Namespace == nil {
 		return fmt.Errorf("you must specify an intentory namespace")
 	}
 
@@ -65,7 +65,7 @@ func runGetInventoriesCmd(cmd *cobra.Command, args []string) error {
 	defer cancel()
 
 	list := &corev1.ConfigMapList{}
-	err = resMgr.Client().List(ctx, list, client.InNamespace(getArgs.namespace), client.MatchingLabels{
+	err = resMgr.Client().List(ctx, list, client.InNamespace(*kubeconfigArgs.Namespace), client.MatchingLabels{
 		"app.kubernetes.io/component":  "inventory",
 		"app.kubernetes.io/created-by": "kustomizer",
 	})

--- a/cmd/kustomizer/get_inventory.go
+++ b/cmd/kustomizer/get_inventory.go
@@ -41,11 +41,8 @@ func runGetInventoryCmd(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("you must specify an intentory name")
 	}
 	name := args[0]
-	if getArgs.namespace == "" {
-		return fmt.Errorf("you must specify a namespace")
-	}
 
-	i := inventory.NewInventory(name, getArgs.namespace)
+	i := inventory.NewInventory(name, *kubeconfigArgs.Namespace)
 
 	kubeClient, err := newKubeClient(kubeconfigArgs)
 	if err != nil {

--- a/cmd/kustomizer/main_test.go
+++ b/cmd/kustomizer/main_test.go
@@ -151,7 +151,6 @@ func executeCommand(cmd string) (string, error) {
 
 func resetCmdArgs() {
 	applyArgs = applyFlags{}
-	getArgs = getFlags{}
 	buildArgs = buildFlags{}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/stefanprodan/kustomizer
 go 1.17
 
 require (
-	github.com/fluxcd/pkg/ssa v0.5.0
+	github.com/fluxcd/pkg/ssa v0.6.1
 	github.com/mattn/go-shellwords v1.0.12
 	github.com/olekukonko/tablewriter v0.0.4
 	github.com/onsi/gomega v1.15.0

--- a/go.sum
+++ b/go.sum
@@ -164,8 +164,8 @@ github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d/go.mod h1:ZZM
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
-github.com/fluxcd/pkg/ssa v0.5.0 h1:5ruagNJNMQipaYgtlfo0EuRTOlgwvkjLsdmedviqtbk=
-github.com/fluxcd/pkg/ssa v0.5.0/go.mod h1:rFhWBX9/TfNwSFR+5NHOGnpl9OsWdaQrG5CggN+74EQ=
+github.com/fluxcd/pkg/ssa v0.6.1 h1:sBdd8EBZ6L9o8SugobE6PtRh24PQ6zTH9SweoYij8to=
+github.com/fluxcd/pkg/ssa v0.6.1/go.mod h1:rFhWBX9/TfNwSFR+5NHOGnpl9OsWdaQrG5CggN+74EQ=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/form3tech-oss/jwt-go v3.2.3+incompatible h1:7ZaBxOI7TMoYBfyA3cQHErNNyAWIKUMIwqxEtgHOs5c=
 github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,156 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/fluxcd/pkg/ssa"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"path/filepath"
+	"sigs.k8s.io/yaml"
+)
+
+const (
+	KustomizerConfigKind        = "Config"
+	KustomizerConfigApiVersion  = "kustomizer.dev/v1"
+	KustomizerFieldManagerName  = "kustomizer"
+	KustomizerFieldManagerGroup = "inventory.kustomizer.dev"
+)
+
+type Config struct {
+	metav1.TypeMeta `json:",inline"`
+
+	// ApplyOrder holds the list of the Kubernetes API Kinds that
+	// describes in which order they are reconciled.
+	ApplyOrder *KindOrder `json:"applyOrder,omitempty"`
+
+	// FieldManager holds the manager name and group used for server-side apply.
+	FieldManager *FieldManager `json:"fieldManager,omitempty"`
+}
+
+type FieldManager struct {
+	// Name sets the field manager for the reconciled objects.
+	Name string `json:"name"`
+
+	// Group sets the owner label key prefix.
+	Group string `json:"group"`
+}
+
+// KindOrder holds the list of the Kubernetes API Kinds that
+// describes in which order they are reconciled.
+type KindOrder struct {
+	// First contains the list of Kubernetes API Kinds
+	// that are applied first and delete last.
+	First []string `json:"first"`
+
+	// Last contains the list of Kubernetes API Kinds
+	// that are applied last and delete first.
+	Last []string `json:"last"`
+}
+
+// NewConfig returns a config with the default apply order.
+func NewConfig() *Config {
+	return &Config{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       KustomizerConfigKind,
+			APIVersion: KustomizerConfigApiVersion,
+		},
+		ApplyOrder:   defaultKindOrder(),
+		FieldManager: defaultFieldManager(),
+	}
+}
+
+func defaultKindOrder() *KindOrder {
+	return &KindOrder{
+		First: ssa.ReconcileOrder.First,
+		Last:  ssa.ReconcileOrder.Last,
+	}
+}
+
+func defaultFieldManager() *FieldManager {
+	return &FieldManager{
+		Name:  KustomizerFieldManagerName,
+		Group: KustomizerFieldManagerGroup,
+	}
+}
+
+// DefaultConfigPath returns '$HOME/.kustomizer/config'
+func DefaultConfigPath() (string, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(homeDir, ".kustomizer/config"), nil
+}
+
+// Read loads the config from the specified path,
+// if the config file is not found, a default is returned.
+func Read(configPath string) (*Config, error) {
+	if configPath == "" {
+		p, err := DefaultConfigPath()
+		if err != nil {
+			return nil, fmt.Errorf("$HOME dir can't be determined, error: %w", err)
+		}
+		configPath = p
+	}
+
+	if _, err := os.Stat(configPath); errors.Is(err, os.ErrNotExist) {
+		return NewConfig(), nil
+	}
+
+	cfgData, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil, err
+	}
+
+	cfg := &Config{}
+	if err := yaml.Unmarshal(cfgData, cfg); err != nil {
+		return nil, err
+	}
+
+	if cfg.ApplyOrder == nil {
+		cfg.ApplyOrder = defaultKindOrder()
+	}
+
+	if cfg.FieldManager == nil {
+		cfg.FieldManager = defaultFieldManager()
+	}
+
+	if cfg.FieldManager.Name == "" {
+		return nil, fmt.Errorf("the filed manager name can't be empty")
+	}
+
+	if cfg.FieldManager.Group == "" {
+		return nil, fmt.Errorf("the filed manager group can't be empty")
+	}
+
+	return cfg, nil
+}
+
+// Write saves the config at the given path, if no path is specified
+// it will create or override '$HOME/.kustomizer/config'.
+func (c *Config) Write(configPath string) error {
+	if configPath == "" {
+		p, err := DefaultConfigPath()
+		if err != nil {
+			return err
+		}
+		configPath = p
+	}
+
+	if err := os.MkdirAll(filepath.Dir(configPath), os.FileMode(0755)); err != nil {
+		return err
+	}
+
+	cfgData, err := yaml.Marshal(c)
+	if err != nil {
+		return err
+	}
+
+	if err := os.WriteFile(configPath, cfgData, os.FileMode(0666)); err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Features

- load the YAML config at startup from `$HOME/.kustomizer/config` if found
- add `config init` command to generate a config file with default values
- and `config view` command to display the current configuration
- allow configuring the server-side apply field manager
- allow configuring the apply order of Kubernetes Kinds (fix: #27)

## How to change the apply order

- Create a config file

```console
$ kustomizer config init
config written to /Users/me/.kustomizer/config
```

- View the config

```console
$ kustomizer config view
apiVersion: kustomizer.dev/v1
kind: Config
applyOrder:
  first:
  - CustomResourceDefinition
  - Namespace
  - ResourceQuota
  - StorageClass
  - ServiceAccount
  - PodSecurityPolicy
  - Role
  - ClusterRole
  - RoleBinding
  - ClusterRoleBinding
  - ConfigMap
  - Secret
  - Service
  - LimitRange
  - PriorityClass
  - Deployment
  - StatefulSet
  - CronJob
  - PodDisruptionBudget
  last:
  - MutatingWebhookConfiguration
  - ValidatingWebhookConfiguration
fieldManager:
  group: inventory.kustomizer.dev
  name: kustomizer
```

- Edit the config and add `NetworkPolicy` to `applyOrder.first` before `Deployment`.
- Verify that the network polices are placed before deployments with `kustomizer build`.
