### PR TITLE
Implement diff artifact command

### DIFF
--- a/cmd/kustomizer/apply_inventory.go
+++ b/cmd/kustomizer/apply_inventory.go
@@ -37,6 +37,9 @@ var applyInventoryCmd = &cobra.Command{
   # Apply an inventory from remote OCI artifacts
   kustomizer apply inventory my-app -n apps -a oci://registry/org/repo:latest
 
+  # Apply an inventory using an OCI artifact digest
+  kustomizer apply inventory my-app -n apps -a oci://registry/org/repo@sha256:<digest>
+
   # Apply an inventory from remote OCI artifacts and local patches
   kustomizer apply inventory my-app -n apps -a oci://registry/org/repo:latest -p ./patches/safe-to-evict.yaml
 

--- a/cmd/kustomizer/diff.go
+++ b/cmd/kustomizer/diff.go
@@ -22,7 +22,7 @@ import (
 
 var diffCmd = &cobra.Command{
 	Use:   "diff",
-	Short: "Diff prints the differences between the local and the live version.",
+	Short: "Diff prints the differences between two sets of Kubernetes resources.",
 }
 
 func init() {

--- a/cmd/kustomizer/diff_artifact.go
+++ b/cmd/kustomizer/diff_artifact.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2021 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sigs.k8s.io/yaml"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/stefanprodan/kustomizer/pkg/registry"
+)
+
+var diffArtifactCmd = &cobra.Command{
+	Use:   "artifact",
+	Short: "Diff compares the two artifacts and prints the differences between the Kubernetes resources to stdout.",
+	Example: `  kustomizer diff artifact <oci url1> <oci url2>
+
+  # Diff artifact by tag
+  kustomizer diff artifact oci://registry/org/repo:v1 oci://registry/org/repo:v2
+
+  # Diff artifact by digest
+  kustomizer diff artifact oci://registry/org/repo@sha245:<digest-1> oci://registry/org/repo@sha245:<digest-2>
+`,
+	RunE: runDiffArtifactCmd,
+}
+
+func init() {
+	diffCmd.AddCommand(diffArtifactCmd)
+}
+
+func runDiffArtifactCmd(cmd *cobra.Command, args []string) error {
+	if len(args) != 2 {
+		return fmt.Errorf("you must specify two artifact URLs")
+	}
+
+	tmpDir, err := os.MkdirTemp("", *kubeconfigArgs.Namespace)
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tmpDir)
+
+	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
+	defer cancel()
+
+	files := []string{}
+	for i, ociURL := range args {
+		url, err := registry.ParseURL(ociURL)
+		if err != nil {
+			return err
+		}
+
+		data, _, err := registry.Pull(ctx, url)
+		if err != nil {
+			return fmt.Errorf("pulling %s failed: %w", url, err)
+		}
+		res, _ := yaml.Marshal(data)
+		resPath := filepath.Join(tmpDir, fmt.Sprintf("%d.yaml", i))
+		if err := os.WriteFile(resPath, res, 0644); err != nil {
+			return err
+		}
+		files = append(files, resPath)
+	}
+
+	out, _ := exec.Command("diff", "-N", "-u", files[0], files[1]).Output()
+	for i, line := range strings.Split(string(out), "\n") {
+		if i > 1 && len(line) > 0 {
+			rootCmd.Println(line)
+		}
+	}
+
+	return nil
+}

--- a/cmd/kustomizer/diff_artifact_test.go
+++ b/cmd/kustomizer/diff_artifact_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2021 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestDiffArtifact(t *testing.T) {
+	g := NewWithT(t)
+	id := randStringRunes(5)
+
+	artifact1 := fmt.Sprintf("oci://%s/%s:%s", registryHost, id, "v1")
+	dir1, err := makeTestDir(id+"1", testManifests(id, id, false))
+	g.Expect(err).NotTo(HaveOccurred())
+
+	artifact2 := fmt.Sprintf("oci://%s/%s:%s", registryHost, id, "v2")
+	dir2, err := makeTestDir(id+"2", testManifests(id, id, true))
+	g.Expect(err).NotTo(HaveOccurred())
+
+	t.Run("push artifacts", func(t *testing.T) {
+		_, err = executeCommand(fmt.Sprintf(
+			"push artifact %s -k %s",
+			artifact1,
+			dir1,
+		))
+
+		g.Expect(err).NotTo(HaveOccurred())
+
+		_, err = executeCommand(fmt.Sprintf(
+			"push artifact %s -k %s",
+			artifact2,
+			dir2,
+		))
+
+		g.Expect(err).NotTo(HaveOccurred())
+	})
+
+	t.Run("pull artifact", func(t *testing.T) {
+		output, err := executeCommand(fmt.Sprintf(
+			"diff artifact %s %s",
+			artifact1,
+			artifact2,
+		))
+
+		g.Expect(err).NotTo(HaveOccurred())
+		t.Logf("\n%s", output)
+		g.Expect(output).To(MatchRegexp("immutable"))
+	})
+}

--- a/cmd/kustomizer/diff_inventory_test.go
+++ b/cmd/kustomizer/diff_inventory_test.go
@@ -23,9 +23,9 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestDiff(t *testing.T) {
+func TestDiffInventory(t *testing.T) {
 	g := NewWithT(t)
-	id := "apply-" + randStringRunes(5)
+	id := "diff-" + randStringRunes(5)
 
 	err := createNamespace(id)
 	g.Expect(err).NotTo(HaveOccurred())

--- a/cmd/kustomizer/pull_artifact.go
+++ b/cmd/kustomizer/pull_artifact.go
@@ -33,16 +33,13 @@ For private registries, the pull command uses the credentials from '~/.docker/co
 	Example: `  kustomizer pull artifact <oci url>
 
   # Pull Kubernetes manifests from an OCI artifact hosted on Docker Hub
-  kustomizer pull oci://docker.io/user/repo:v1.0.0 > manifests.yaml
+  kustomizer pull artifact oci://docker.io/user/repo:v1.0.0 > manifests.yaml
 
   # Pull an OCI artifact using the digest and write the Kubernetes manifests to stdout
-  kustomizer pull oci://docker.io/user/repo@sha256:<digest>
+  kustomizer pull artifact oci://docker.io/user/repo@sha256:<digest>
 
   # Pull the latest artifact from a local registry
-  kustomizer pull oci://localhost:5000/repo
-
-  # Apply Kubernetes manifests from an OCI artifact 
-  kustomizer pull oci://docker.io/user/repo:v1.0.0 | kustomizer apply -i test -f-
+  kustomizer pull artifact oci://localhost:5000/repo
 `,
 	RunE: runPullArtifactCmd,
 }

--- a/cmd/kustomizer/push_artifact.go
+++ b/cmd/kustomizer/push_artifact.go
@@ -36,16 +36,16 @@ var pushArtifactCmd = &cobra.Command{
 builds the manifests into a multi-doc YAML, packages the YAML file into an OCI artifact and
 pushes the image to the container registry.
 The push command uses the credentials from '~/.docker/config.json'.`,
-	Example: `  kustomizer push <oci url> -k <overlay path> [-f <dir path>|<file path>]
+	Example: `  kustomizer push artifact <oci url> -k <overlay path> [-f <dir path>|<file path>]
 
   # Build Kubernetes plain manifests and push the resulting multi-doc YAML to Docker Hub
-  kustomizer push oci://docker.io/user/repo:v1.0.0 -f ./deploy/manifests
+  kustomizer push artifact oci://docker.io/user/repo:v1.0.0 -f ./deploy/manifests
 
   # Build a Kustomize overlay and push the resulting multi-doc YAML to GitHub Container Registry
-  kustomizer push oci://ghcr.io/user/repo:v1.0.0 -k ./deploy/production 
+  kustomizer push artifact oci://ghcr.io/user/repo:v1.0.0 -k ./deploy/production 
 
   # Push to a local registry
-  kustomizer push oci://localhost:5000/repo:latest -f ./deploy/manifests 
+  kustomizer push artifact oci://localhost:5000/repo:latest -f ./deploy/manifests 
 `,
 	RunE: runPushArtifactCmd,
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 # Kustomizer
 
 Kustomizer is an experimental package manager for distributing Kubernetes configuration as OCI artifacts.
-It offers commands to publish, fetch, customize, validate, apply and prune Kubernetes resources.
+It offers commands to publish, fetch, diff, customize, validate, apply and prune Kubernetes resources.
 
 ## Concepts
 
@@ -17,7 +17,8 @@ Kustomizer comes with commands for managing OCI artifacts:
 - `kustomizer tag artifact oci://<image-url>:<tag> <new-tag>`
 - `kustomizer pull artifact oci://<image-url>:<tag>`
 - `kustomizer inspect artifact oci://<image-url>:<tag>`
-
+- `kustomizer diff artifact <oci url> <oci url>`
+ 
 Kustomizer is compatible with Docker Hub, GHCR, ACR, ECR, GCR, Artifactory,
 self-hosted Docker Registry and others. For auth, it uses the credentials from `~/.docker/config.json`.
 
@@ -44,7 +45,9 @@ list, diff, update, and delete inventories:
 - `kustomizer inspect inventory <name> --namespace <namespace>`
 - `kustomizer delete inventory <name> --namespace <namespace>`
 
-To connect to Kubernetes API, Kustomizer uses the current context from `~/.kube/config`.
+When applying resources from OCI artifacts, Kustomizer saves the artifacts URL and
+the image SHA-2 digest in the inventory. For deterministic and repeatable apply operations,
+you could use digests instead of tags.
 
 ## Comparison with other tools
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,6 +46,7 @@ nav:
           - Push: cmd/kustomizer_push_artifact.md
           - Tag: cmd/kustomizer_tag_artifact.md
           - Pull: cmd/kustomizer_pull_artifact.md
+          - Diff: cmd/kustomizer_diff_artifact.md
           - Inspect: cmd/kustomizer_inspect_artifact.md
       - Inventory:
           - Apply: cmd/kustomizer_apply_inventory.md


### PR DESCRIPTION
```console
$ kustomizer diff artifact -h
Diff compares the two artifacts and prints the differences between the Kubernetes resources to stdout.

Usage:
  kustomizer diff artifact [flags]

Examples:
  kustomizer diff artifact <oci url1> <oci url2>

  # Diff artifact by tag
  kustomizer diff artifact oci://registry/org/repo:v1 oci://registry/org/repo:v2

  # Diff artifact by digest
  kustomizer diff artifact oci://registry/org/repo@sha245:<digest-1> oci://registry/org/repo@sha245:<digest-2>
```