### PR TITLE
Extend patching support

### DIFF
--- a/cmd/kustomizer/build_inventory.go
+++ b/cmd/kustomizer/build_inventory.go
@@ -336,7 +336,15 @@ func applyPatches(kFilePath string, objects []*unstructured.Unstructured) ([]byt
 		return nil, err
 	}
 
+	kustomization.Namespace = template.Namespace
+	kustomization.NamePrefix = template.NamePrefix
+	kustomization.NameSuffix = template.NameSuffix
+	kustomization.CommonLabels = template.CommonLabels
+	kustomization.CommonAnnotations = template.CommonAnnotations
 	kustomization.Patches = template.Patches
+	kustomization.PatchesJson6902 = template.PatchesJson6902
+	kustomization.PatchesStrategicMerge = template.PatchesStrategicMerge
+	kustomization.Images = template.Images
 
 	d, err := yaml.Marshal(kustomization)
 	if err != nil {

--- a/cmd/kustomizer/build_inventory_test.go
+++ b/cmd/kustomizer/build_inventory_test.go
@@ -38,6 +38,8 @@ func TestBuild(t *testing.T) {
 				Body: `---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+commonAnnotations:
+  test: test-annotation
 patches:
   - target:
       kind: ConfigMap
@@ -45,7 +47,7 @@ patches:
       - op: add
         path: /data/patch
         value:
-          test
+          test-patch
 `,
 			},
 		},
@@ -76,6 +78,7 @@ patches:
 
 		g.Expect(err).NotTo(HaveOccurred())
 		t.Logf("\n%s", output)
-		g.Expect(output).To(MatchRegexp("patch"))
+		g.Expect(output).To(MatchRegexp("test-annotation"))
+		g.Expect(output).To(MatchRegexp("test-patch"))
 	})
 }


### PR DESCRIPTION
Add support for changing the resources' namespace, images, labels, annotations, name prefix and suffix using in-line Kustomize patches.
