### PR TITLE
Add command to list and filter artifacts by semver

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Kustomizer comes with commands for managing OCI artifacts:
 
 - `kustomizer push artifact oci://<image-url>:<tag> -k [-f] [-p]`
 - `kustomizer tag artifact oci://<image-url>:<tag> <new-tag>`
+- `kustomizer list artifacts oci://<repo-url> --semver <condition>`
 - `kustomizer pull artifact oci://<image-url>:<tag>`
 - `kustomizer inspect artifact oci://<image-url>:<tag>`
 - `kustomizer diff artifact <oci url> <oci url>`

--- a/cmd/kustomizer/list.go
+++ b/cmd/kustomizer/list.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2021 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List artifacts from an OCI repository.",
+}
+
+func init() {
+	rootCmd.AddCommand(listCmd)
+}

--- a/cmd/kustomizer/list_artifact.go
+++ b/cmd/kustomizer/list_artifact.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2021 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/spf13/cobra"
+
+	"github.com/stefanprodan/kustomizer/pkg/registry"
+)
+
+var listArtifactCmd = &cobra.Command{
+	Use:     "artifact",
+	Aliases: []string{"artifacts"},
+	Short:   "List the versions of an OCI artifact.",
+	Long: `The list command fetches the tags of the specified OCI artifact from its image repository.
+If a semantic version condition is specified, the tags are filtered and ordered by semver.
+For private registries, the list command uses the credentials from '~/.docker/config.json'.`,
+	Example: `  kustomizer list artifacts <oci repository url> --semver <condition>
+
+  # List all versions ordered by semver
+  kustomizer list artifacts oci://docker.io/user/repo --semver="*"
+
+  # List all versions including prerelease ordered by semver
+  kustomizer list artifacts oci://docker.io/user/repo --semver=">0.0.0-0"
+
+  # List all versions in the 1.0 range
+  kustomizer list artifacts oci://docker.io/user/repo --semver="~1.0"
+
+  # List all versions in the 1.0 range including prerelease
+  kustomizer list artifacts oci://docker.io/user/repo --semver="~1.0-0"
+`,
+	RunE: runListArtifactCmd,
+}
+
+type listArtifactFlags struct {
+	semverExp string
+}
+
+var listArtifactArgs listArtifactFlags
+
+func init() {
+	listArtifactCmd.Flags().StringVar(&listArtifactArgs.semverExp, "semver", "",
+		"Filter the results based on a semantic version constraint e.g. '1.x'.")
+	listCmd.AddCommand(listArtifactCmd)
+}
+
+func runListArtifactCmd(cmd *cobra.Command, args []string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("you must specify an artifact repository e.g. 'oci://docker.io/user/repo'")
+	}
+
+	url, err := registry.ParseRepositoryURL(args[0])
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), rootArgs.timeout)
+	defer cancel()
+
+	tags, err := registry.List(ctx, url)
+	if err != nil {
+		return fmt.Errorf("pulling %s failed: %w", url, err)
+	}
+
+	var rows [][]string
+
+	if exp := listArtifactArgs.semverExp; exp != "" {
+		c, err := semver.NewConstraint(exp)
+		if err != nil {
+			return fmt.Errorf("semver '%s' parse error: %w", exp, err)
+		}
+
+		var matchingVersions []*semver.Version
+		for _, t := range tags {
+			v, err := semver.NewVersion(t)
+			if err != nil {
+				continue
+			}
+
+			if c != nil && !c.Check(v) {
+				continue
+			}
+
+			matchingVersions = append(matchingVersions, v)
+		}
+
+		sort.Sort(sort.Reverse(semver.Collection(matchingVersions)))
+
+		for _, ver := range matchingVersions {
+			row := []string{ver.String(), fmt.Sprintf("%s:%s", url, ver.Original())}
+			rows = append(rows, row)
+		}
+	} else {
+		for _, tag := range tags {
+			// exclude cosign signatures
+			if !strings.HasSuffix(tag, ".sig") {
+				row := []string{tag, fmt.Sprintf("%s:%s", url, tag)}
+				rows = append(rows, row)
+			}
+		}
+	}
+
+	printTable(rootCmd.OutOrStdout(), []string{"version", "url"}, rows)
+
+	return nil
+}

--- a/cmd/kustomizer/list_artifact_test.go
+++ b/cmd/kustomizer/list_artifact_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2021 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestListArtifact(t *testing.T) {
+	g := NewWithT(t)
+	id := randStringRunes(5)
+
+	ver1 := "v1.0.0"
+	artifact1 := fmt.Sprintf("oci://%s/%s:%s", registryHost, id, ver1)
+	dir1, err := makeTestDir(id+"1", testManifests(id, id, false))
+	g.Expect(err).NotTo(HaveOccurred())
+
+	ver2 := "v2.0.0-rc.1"
+	artifact2 := fmt.Sprintf("oci://%s/%s:%s", registryHost, id, ver2)
+	dir2, err := makeTestDir(id+"2", testManifests(id, id, true))
+	g.Expect(err).NotTo(HaveOccurred())
+
+	t.Run("push artifacts", func(t *testing.T) {
+		_, err = executeCommand(fmt.Sprintf(
+			"push artifact %s -k %s",
+			artifact1,
+			dir1,
+		))
+
+		g.Expect(err).NotTo(HaveOccurred())
+
+		_, err = executeCommand(fmt.Sprintf(
+			"push artifact %s -k %s",
+			artifact2,
+			dir2,
+		))
+
+		g.Expect(err).NotTo(HaveOccurred())
+	})
+
+	t.Run("lists all versions", func(t *testing.T) {
+		output, err := executeCommand(fmt.Sprintf(
+			"list artifact oci://%s/%s",
+			registryHost,
+			id,
+		))
+
+		g.Expect(err).NotTo(HaveOccurred())
+		t.Logf("\n%s", output)
+		g.Expect(output).To(MatchRegexp(ver1))
+		g.Expect(output).To(MatchRegexp(ver2))
+	})
+
+	t.Run("lists prereleases", func(t *testing.T) {
+		output, err := executeCommand(fmt.Sprintf(
+			"list artifact oci://%s/%s --semver 2.x-0",
+			registryHost,
+			id,
+		))
+
+		g.Expect(err).NotTo(HaveOccurred())
+		t.Logf("\n%s", output)
+		g.Expect(output).To(Not(MatchRegexp(ver1)))
+		g.Expect(output).To(MatchRegexp(ver2))
+	})
+
+}

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -131,9 +131,20 @@ kustomizer tag artifact oci://${CONFIG_IMAGE}:${CONFIG_VERSION} latest
 
 ## Deploy the app on Kubernetes
 
+### List the app versions
+
+List all the available versions of the app config ordered by semver:
+
+```console
+$ kustomizer list artifacts oci://${CONFIG_IMAGE} --semver="*"
+VERSION	URL                                                  
+1.0.1  	oci://ghcr.io/stefanprodan/kustomizer-demo-app:1.0.1	
+1.0.0  	oci://ghcr.io/stefanprodan/kustomizer-demo-app:1.0.0
+```
+
 ### Install the app
 
-Apply the Kubernetes configuration from GHCR:
+Apply the `1.0.0` version of the Kubernetes configuration from the GHCR repository:
 
 ```console
 $ kustomizer apply inventory kustomizer-demo-app --wait --prune \

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,7 @@ Kustomizer comes with commands for managing OCI artifacts:
 
 - `kustomizer push artifact oci://<image-url>:<tag> -k [-f] [-p]`
 - `kustomizer tag artifact oci://<image-url>:<tag> <new-tag>`
+- `kustomizer list artifacts oci://<repo-url> --semver <condition>`
 - `kustomizer pull artifact oci://<image-url>:<tag>`
 - `kustomizer inspect artifact oci://<image-url>:<tag>`
 - `kustomizer diff artifact <oci url> <oci url>`

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/stefanprodan/kustomizer
 go 1.17
 
 require (
+	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/distribution/distribution/v3 v3.0.0-20211217182000-52e8a12674e6
 	github.com/fluxcd/pkg/ssa v0.7.0
 	github.com/google/go-containerregistry v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -81,6 +81,8 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd h1:sjQovDkwrZp8u+gxLtPgKGjk5hCxuy2hrRejBTA9xFU=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
+github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
+github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/Microsoft/go-winio v0.4.11/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5/go.mod h1:tTuCMEN+UleMWgg9dVx4Hu52b1bJo+59jBh3ajtinzw=

--- a/pkg/registry/list.go
+++ b/pkg/registry/list.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2021 Stefan Prodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package registry
+
+import (
+	"context"
+	"sort"
+
+	"github.com/google/go-containerregistry/pkg/crane"
+)
+
+func List(ctx context.Context, repo string) ([]string, error) {
+	tags, err := crane.ListTags(repo, craneOptions(ctx)...)
+	if err != nil {
+		return nil, err
+	}
+
+	sort.Slice(tags, func(i, j int) bool { return tags[i] > tags[j] })
+
+	return tags, nil
+}

--- a/pkg/registry/utils.go
+++ b/pkg/registry/utils.go
@@ -40,6 +40,20 @@ func ParseURL(ociURL string) (string, error) {
 	return url, nil
 }
 
+func ParseRepositoryURL(ociURL string) (string, error) {
+	if !strings.HasPrefix(ociURL, URLPrefix) {
+		return "", fmt.Errorf("URL must be in format 'oci://<domain>/<org>/<repo>'")
+	}
+
+	url := strings.TrimPrefix(ociURL, URLPrefix)
+	ref, err := name.ParseReference(url)
+	if err != nil {
+		return "", fmt.Errorf("'%s' invalid: %w", ociURL, err)
+	}
+
+	return fmt.Sprintf("%s/%s", ref.Context().RegistryStr(), ref.Context().RepositoryStr()), nil
+}
+
 func craneOptions(ctx context.Context) []crane.Option {
 	return []crane.Option{
 		crane.WithContext(ctx),


### PR DESCRIPTION
The list command fetches the tags of the specified OCI artifact from its image repository.
If a semantic version condition is specified, the tags are filtered and ordered by semver.
For private registries, the list command uses the credentials from `~/.docker/config.json`.

```
Usage:
  kustomizer list artifact [flags]

Aliases:
  artifact, artifacts

Examples:
  kustomizer list artifacts <oci repository url> --semver <condition>

  # List all versions ordered by semver
  kustomizer list artifacts oci://docker.io/user/repo --semver="*"

  # List all versions including prerelease ordered by semver
  kustomizer list artifacts oci://docker.io/user/repo --semver=">0.0.0-0"

  # List all versions in the 1.0 range
  kustomizer list artifacts oci://docker.io/user/repo --semver="~1.0"

  # List all versions in the 1.0 range including prerelease
  kustomizer list artifacts oci://docker.io/user/repo --semver="~1.0-0"


Flags:
  -h, --help            help for artifact
      --semver string   Filter the results based on a semantic version constraint e.g. '1.x'.
```