### PR TITLE
Update fluxcd/pkg/ssa to v0.8.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	filippo.io/age v1.0.0
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/distribution/distribution/v3 v3.0.0-20211217182000-52e8a12674e6
-	github.com/fluxcd/pkg/ssa v0.7.0
+	github.com/fluxcd/pkg/ssa v0.8.0
 	github.com/google/go-containerregistry v0.7.0
 	github.com/mattn/go-shellwords v1.0.12
 	github.com/olekukonko/tablewriter v0.0.4

--- a/go.sum
+++ b/go.sum
@@ -382,8 +382,8 @@ github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwo
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/felixge/httpsnoop v1.0.1 h1:lvB5Jl89CsZtGIWuTcDM1E/vkVs49/Ml7JJe07l8SPQ=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
-github.com/fluxcd/pkg/ssa v0.7.0 h1:Svek9UO2whyQrePZW03XCX7ytUtZvJ2R01buXQKkUyU=
-github.com/fluxcd/pkg/ssa v0.7.0/go.mod h1:3brodT9mai+iKz4nizqZUESITGMoMr4CCdt5MdfyTXw=
+github.com/fluxcd/pkg/ssa v0.8.0 h1:f3fNpKFPncCoWMDvxnTqX+8LAAMb3ZXc1N41mzw54k8=
+github.com/fluxcd/pkg/ssa v0.8.0/go.mod h1:3brodT9mai+iKz4nizqZUESITGMoMr4CCdt5MdfyTXw=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVBjqR7JHJk0brhHOZYGmfBYOrK0ZhYMEtBr4=


### PR DESCRIPTION
Update fluxcd/pkg/ssa to v0.8.0 that implements a [workaround](https://github.com/fluxcd/pkg/pull/207) for a Kubernetes API server-side apply dry-run bug where the HPA custom metrics are duplicated.
