### PR TITLE
Publish SBOM in SPDX format

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,12 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: 1.17.x
-      - uses: sigstore/cosign-installer@main
+      - name: Setup Syft
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | \
+          sh -s -- -b /usr/local/bin v0.32.0
+      - name: Setup Cosign
+        uses: sigstore/cosign-installer@main
       - name: Write signing key to tmp
         run: echo "${{ secrets.COSIGN_KEY }}" > /tmp/cosign.key
       - name: Download release notes utility

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -44,6 +44,8 @@ signs:
     stdin: '{{ .Env.COSIGN_PASSWORD }}'
     args: ["sign-blob", "--key=/tmp/cosign.key", "--output=${signature}", "${artifact}"]
     artifacts: all
+sboms:
+  - artifacts: archive
 brews:
   - name: kustomizer
     tap:


### PR DESCRIPTION
Use Syft and GoReleaser to generate and publish a SBOM in SPDX format.