### PR TITLE
ci: Push multi-arch image to GHCR

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,19 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: 1.17.x
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+      - name: Setup Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: stefanaprodan
+          password: ${{ secrets.PUSH_GITHUB_TOKEN }}
       - name: Setup Syft
         uses: fluxcd/pkg//actions/sbom@f4d04dc877f3ae6486d8f8a605666e0e757dd2fe
       - name: Setup Cosign

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@
 bin/
 testbin/
 docs/cmd/
+Dockerfile.distroless

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -71,3 +71,51 @@ brews:
       (fish_completion/"kustomizer.fish").write fish_output
     test: |
       system "#{bin}/kustomizer --version"
+before:
+  hooks:
+    - make dockerfile
+dockers:
+  - image_templates:
+      - 'ghcr.io/stefanprodan/{{ .ProjectName }}:{{ .Tag }}-amd64'
+    dockerfile: Dockerfile.distroless
+    use_buildx: true
+    goos: linux
+    goarch: amd64
+    build_flag_templates:
+      - "--pull"
+      - "--build-arg=ARCH=linux/amd64"
+      - "--label=org.opencontainers.image.created={{ .Date }}"
+      - "--label=org.opencontainers.image.name={{ .ProjectName }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.source={{ .GitURL }}"
+      - "--platform=linux/amd64"
+  - image_templates:
+      - 'ghcr.io/stefanprodan/{{ .ProjectName }}:{{ .Tag }}-arm64'
+    dockerfile: Dockerfile.distroless
+    use_buildx: true
+    goos: linux
+    goarch: arm64
+    build_flag_templates:
+      - "--pull"
+      - "--build-arg=ARCH=linux/arm64"
+      - "--label=org.opencontainers.image.created={{ .Date }}"
+      - "--label=org.opencontainers.image.name={{ .ProjectName }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.source={{ .GitURL }}"
+      - "--platform=linux/arm64"
+docker_manifests:
+  - name_template: 'ghcr.io/stefanprodan/{{ .ProjectName }}:{{ .Tag }}'
+    image_templates:
+      - 'ghcr.io/stefanprodan/{{ .ProjectName }}:{{ .Tag }}-amd64'
+      - 'ghcr.io/stefanprodan/{{ .ProjectName }}:{{ .Tag }}-arm64'
+  - name_template: 'ghcr.io/stefanprodan/{{ .ProjectName }}:latest'
+    image_templates:
+      - 'ghcr.io/stefanprodan/{{ .ProjectName }}:{{ .Tag }}-amd64'
+      - 'ghcr.io/stefanprodan/{{ .ProjectName }}:{{ .Tag }}-arm64'
+docker_signs:
+  - cmd: cosign
+    stdin: '{{ .Env.COSIGN_PASSWORD }}'
+    args: ["sign", "--key=/tmp/cosign.key", "${artifact}"]
+    artifacts: all

--- a/Makefile
+++ b/Makefile
@@ -71,3 +71,9 @@ publish-demo:
 	kustomizer push artifact -k ./examples/demo-app oci://$(DEMO_IMAGE):$(DEMO_TAG) --sign --cosign-key ~/.cosign/cosign.key
 	kustomizer tag artifact oci://$(DEMO_IMAGE):$(DEMO_TAG) latest
 	kustomizer inspect artifact oci://$(DEMO_IMAGE)  --verify --key ~/.cosign/cosign.pub
+
+dockerfile:
+	echo \
+FROM gcr.io/distroless/static\\n\
+COPY --chmod=755 kustomizer /\\n\
+CMD ["/kustomizer"] > Dockerfile.distroless


### PR DESCRIPTION
Release workflow changes:
- Build multi-arch (amd64 and arm64) container image based on `gcr.io/distroless/static`
- Push images to `ghcr.io/stefanprodan/kustomizer`
- Sign images with cosign, public key https://stefanprodan.keybase.pub/cosign/kustomizer.pub
