### PR TITLE
ci: Sign the release checksums with cosgin

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,11 @@ on:
   push:
     tags: [ 'v*' ]
 
+permissions:
+  contents: write # needed to write releases
+  id-token: write # needed for keyless signing
+  packages: write # needed for ghcr access
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -41,13 +41,22 @@ archives:
     format: zip
     files:
       - LICENSE
+source:
+  enabled: true
+sboms:
+  - id: source
+    artifacts: source
+checksum:
+  name_template: 'checksums.txt'
 signs:
   - cmd: cosign
     stdin: '{{ .Env.COSIGN_PASSWORD }}'
-    args: ["sign-blob", "--key=/tmp/cosign.key", "--output=${signature}", "${artifact}"]
-    artifacts: all
-sboms:
-  - artifacts: archive
+    args:
+      - sign-blob
+      - '--key=/tmp/cosign.key'
+      - '--output-signature=${signature}'
+      - '${artifact}'
+    artifacts: checksum
 brews:
   - name: kustomizer
     tap:


### PR DESCRIPTION
Release workflow changes:
- add source code to release artifacts
- generate sbom from the source code
- add sbom to checksums
- sigh the checksums.txt with cosign