### PR TITLE
Add source and revision metadata to artifacts

### DIFF
--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -49,7 +49,9 @@ jobs:
         uses: stefanprodan/kustomizer/action@main
       - name: Push
         run: |
-          kustomizer push artifact ${ARTIFACT}:${GITHUB_REF_NAME} -f ./deploy
+          kustomizer push artifact ${ARTIFACT}:${{ github.ref_name }} -f ./deploy \
+          	--source=${{ github.repositoryUrl }} \
+            --revision="${{ github.ref_name }}/${{ github.sha }}"
       - name: Tag latest
         run: |
           kustomizer tag artifact ${ARTIFACT}:${GITHUB_REF_NAME} latest
@@ -85,9 +87,17 @@ jobs:
         uses: sigstore/cosign-installer@main
       - name: Setup kustomizer
         uses: stefanprodan/kustomizer/action@main
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Push and sign
         run: |
-          kustomizer push artifact ${ARTIFACT}:${GITHUB_REF_NAME} -f ./deploy --sign
+          kustomizer push artifact ${ARTIFACT}:${GITHUB_REF_NAME} -f ./deploy --sign \
+          	--source=${{ github.repositoryUrl }} \
+            --revision="${{ github.ref_name }}/${{ github.sha }}"
       - name: Tag latest
         run: |
           kustomizer tag artifact ${ARTIFACT}:${GITHUB_REF_NAME} latest

--- a/pkg/registry/metadata.go
+++ b/pkg/registry/metadata.go
@@ -26,14 +26,18 @@ const (
 	CreatedAnnotation    = "kustomizer.dev/created"
 	EncryptedAnnotation  = "kustomizer.dev/encrypted"
 	AgeEncryptionVersion = "age-encryption.org/v1"
+	SourceAnnotation     = "org.opencontainers.image.source"
+	RevisionAnnotation   = "org.opencontainers.image.revision"
 )
 
 type Metadata struct {
-	Version   string `json:"version"`
-	Checksum  string `json:"checksum"`
-	Created   string `json:"created"`
-	Encrypted string `json:"encrypted,omitempty"`
-	Digest    string `json:"digest,omitempty"`
+	Version        string `json:"version"`
+	Checksum       string `json:"checksum"`
+	Created        string `json:"created"`
+	Encrypted      string `json:"encrypted,omitempty"`
+	Digest         string `json:"digest,omitempty"`
+	SourceURL      string `json:"source_url"`
+	SourceRevision string `json:"source_revision"`
 }
 
 func (m *Metadata) ToAnnotations() map[string]string {
@@ -46,6 +50,15 @@ func (m *Metadata) ToAnnotations() map[string]string {
 	if m.Encrypted != "" {
 		annotations[EncryptedAnnotation] = m.Encrypted
 	}
+
+	if m.SourceURL != "" {
+		annotations[SourceAnnotation] = m.SourceURL
+	}
+
+	if m.SourceRevision != "" {
+		annotations[RevisionAnnotation] = m.SourceRevision
+	}
+
 	return annotations
 }
 
@@ -73,6 +86,14 @@ func GetMetadata(annotations map[string]string) (*Metadata, error) {
 
 	if encrypted, ok := annotations[EncryptedAnnotation]; ok {
 		m.Encrypted = encrypted
+	}
+
+	if sourceURL, ok := annotations[SourceAnnotation]; ok {
+		m.SourceURL = sourceURL
+	}
+
+	if sourceRevision, ok := annotations[RevisionAnnotation]; ok {
+		m.SourceRevision = sourceRevision
 	}
 
 	return &m, nil


### PR DESCRIPTION
Allow specifying the Git source URL and revision when publishing artifacts with `kustomizer push artifact --source --revision`. 

The Git metadata is stored in the OCI artifact manifests as annotations:
- `org.opencontainers.image.source: <GIT-URL>`
- `org.opencontainers.image.revision: <GIT-BRANCH|TAG>/<GIT-SHA>`

The Open Containers annotations make the OCI artifacts produced by Kustomizer compatible with Flux v2.